### PR TITLE
Added support for GitHub refs (branches, tags, commits)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,15 @@ Usage
 
 ### ghdownload(params, dir)
 
-Downloads the latest copy of the `master` branch. This will still work even if the Github API limit has been reached.
+Downloads the latest copy of some Github reference (branch, tag, or commit), or the `master` branch by default (specifically the `master` branch, it does _not_ honor Github's default branch configuration). This will still work even if the Github API limit has been reached.
 
-- **params**: Can either be a Github URL string such as: `https://github.com/jprichardson/node-vcsurl.git`, `git@github.com:jprichardson/node-vcsurl.git`, or `git://github.com/jprichardson/node-vcsurl.git`. It can also be an object containing like so: `{user: 'jprichardson', repo: 'vcsurl'}`.
+- **params**: Can either be:
+     - a Github URL string such as:
+         - `https://github.com/jprichardson/node-vcsurl.git`
+         - `git@github.com:jprichardson/node-vcsurl.git`
+         - `git://github.com/jprichardson/node-vcsurl.git`
+         - and even including a reference, e.g. `https://github.com/jprichardson/node-vcsurl.git#master`
+     - or an object like so: `{user: 'jprichardson', repo: 'vcsurl', ref: 'master'}`
 - **dir**: The output directory. Uses the current working directory if nothing is specified.
 
 Returns a GithubDownloader object that emits events on `dir`, `file`, and `end`.
@@ -37,7 +43,7 @@ Example:
 var ghdownload = require('github-download')
   , exec = require('exec')
 
-ghdownload({user: 'jprichardson', repo: 'node-batchflow'}, process.cwd())
+ghdownload({user: 'jprichardson', repo: 'node-batchflow', ref: 'master'}, process.cwd())
 .on('dir', function(dir) {
   console.log(dir)
 })

--- a/lib/github-download.js
+++ b/lib/github-download.js
@@ -7,10 +7,10 @@ var EventEmitter = require('events').EventEmitter
   , AdmZip = require('adm-zip')
   , util = require('util')
 
-function GithubDownloader (user, repo, branch, dir) {
+function GithubDownloader (user, repo, ref, dir) {
   this.user = user
   this.repo = repo
-  this.branch = branch || 'master'
+  this.ref = ref || 'master'
   this.dir = dir
   this._log = []
   this._getZip = false
@@ -21,12 +21,13 @@ util.inherits(GithubDownloader, EventEmitter)
 GithubDownloader.prototype.start = function() {
   var _this = this 
     , initialUrl = 'https://api.github.com/repos/' + this.user + '/' + this.repo + '/contents/'
-    , rawUrl = 'https://raw.github.com/' + this.user + '/' + this.repo + '/' + this.branch + '/'
+    , initialUrlRef = this.ref ? '?ref=' + this.ref : ''
+    , rawUrl = 'https://raw.github.com/' + this.user + '/' + this.repo + '/' + this.ref + '/'
     , pending = 0
     , gonnaProcess = 0
 
   gonnaProcess += 1
-  requestJSON.call(this, initialUrl, processItems)
+  requestJSON.call(this, initialUrl + initialUrlRef, processItems)
 
   function processItems (items) {
     pending += items.length
@@ -42,7 +43,7 @@ GithubDownloader.prototype.start = function() {
         if (err) _this.emit('error', err)
         _this._log.push(dir)
         gonnaProcess += 1
-        requestJSON.call(_this, initialUrl + item.path, processItems)
+        requestJSON.call(_this, initialUrl + item.path + initialUrlRef, processItems)
         _this.emit('dir', item.path)
         pending -= 1
         checkDone()
@@ -75,8 +76,10 @@ GithubDownloader.prototype.start = function() {
 
 module.exports = function GithubDownload (params, dir) {
   if (typeof params === 'string') {
-    var url = (vcsurl(params) || params).split('/')
-    params = {user: url[url.length - 2], repo: url[url.length - 1]}
+    var pieces = params.split('#');
+    var ref = pieces[1];
+    var url = (vcsurl(pieces[0]) || pieces[0]).split('/')
+    params = {user: url[url.length - 2], repo: url[url.length - 1], ref: ref}
   }
 
   if (typeof params !== 'object')
@@ -85,7 +88,7 @@ module.exports = function GithubDownload (params, dir) {
   //console.dir(params)
 
   dir = dir || process.cwd()
-  var gh = new GithubDownloader(params.user, params.repo, 'master', dir)
+  var gh = new GithubDownloader(params.user, params.repo, params.ref, dir)
   return gh.start()
 }
 
@@ -115,10 +118,10 @@ function downloadZip() {
   })
 
   var tmpdir = generateTempDir()
-    , zipBaseDir = _this.repo + '-' + _this.branch
+    , zipBaseDir = _this.repo + '-' + _this.ref
     , zipFile = path.join(tmpdir, zipBaseDir + '.zip')
 
-  var zipUrl = "https://nodeload.github.com/" + _this.user + "/" + _this.repo + "/zip/" + _this.branch
+  var zipUrl = "https://nodeload.github.com/" + _this.user + "/" + _this.repo + "/zip/" + _this.ref
   _this.emit('zip', zipUrl)
 
   //console.log(zipUrl)


### PR DESCRIPTION
This PR adds support for GitHub refs (branches [other than `master`], tags, commits).  While I did update your README, I did _not_ update your tests.  Take it or leave it, up to you. :gift:
