### PR TITLE
Downloading onto a different drive throws an EXDEV error

### DIFF
--- a/lib/github-download.js
+++ b/lib/github-download.js
@@ -5,7 +5,6 @@ var EventEmitter = require('events').EventEmitter
   , fs = require('fs-extra')
   , AdmZip = require('adm-zip')
   , util = require('util')
-  , rimraf = require('rimraf')
   , cwd = process.cwd()
 
 function GithubDownloader (user, repo, ref, dir) {
@@ -135,7 +134,7 @@ function downloadZip() {
         //console.log(oldPath)
         fs.rename(oldPath, _this.dir, function(err) {
           if (err) _this.emit('error', err)
-          rimraf(tmpdir, function(err) {
+          fs.remove(tmpdir, function(err) {
             if (err) _this.emit('error', err)
             _this.emit('end')
           })


### PR DESCRIPTION
As posted on the [Headstart issues](https://github.com/flovan/headstart/issues/6), downloading files into a directory on an external drive will throw an EXDEV error. This PR puts the tmp folder directly inside of the working directory (cwd) and cleans up afterwards through rimraf.
