### PR TITLE
Fix downloading specific version

### DIFF
--- a/lib/github-download.js
+++ b/lib/github-download.js
@@ -126,8 +126,8 @@ function downloadZip () {
     if (err) _this.emit('error', err)
     request.get(zipUrl).pipe(fs.createWriteStream(zipFile)).on('close', function () {
       // fs.createReadStream(zipFile).pipe(unzip.Extract({path: tmpdir})).on('close', function() {
-      extractZip.call(_this, zipFile, tmpdir, function () {
-        var oldPath = path.join(tmpdir, zipBaseDir)
+      extractZip.call(_this, zipFile, tmpdir, function (extractedFolderName) {
+        var oldPath = path.join(tmpdir, extractedFolderName)
         // console.log(oldPath)
         fs.rename(oldPath, _this.dir, function (err) {
           if (err) _this.emit('error', err)

--- a/lib/github-download.js
+++ b/lib/github-download.js
@@ -125,10 +125,8 @@ function downloadZip () {
   fs.mkdir(tmpdir, function (err) {
     if (err) _this.emit('error', err)
     request.get(zipUrl).pipe(fs.createWriteStream(zipFile)).on('close', function () {
-      // fs.createReadStream(zipFile).pipe(unzip.Extract({path: tmpdir})).on('close', function() {
       extractZip.call(_this, zipFile, tmpdir, function (extractedFolderName) {
         var oldPath = path.join(tmpdir, extractedFolderName)
-        // console.log(oldPath)
         fs.rename(oldPath, _this.dir, function (err) {
           if (err) _this.emit('error', err)
           fs.remove(tmpdir, function (err) {
@@ -139,7 +137,6 @@ function downloadZip () {
       })
     })
   })
-
 }
 
 function generateTempDir () {

--- a/lib/zip.js
+++ b/lib/zip.js
@@ -8,11 +8,12 @@ function extractZip (zipFile, outputDir, callback) {
   var entries = zip.getEntries()
   var pending = entries.length
   var _this = this
+  var folderName = path.basename(entries[0].entryName)
 
   function checkDone (err) {
     if (err) _this.emit('error', err)
     pending -= 1
-    if (pending === 0) callback()
+    if (pending === 0) callback(folderName)
   }
 
   entries.forEach(function (entry) {


### PR DESCRIPTION
Hey,
Great library first of all.

I came a cross a problem, here is my code:

``` javascript
var ghdownload = require('github-download');
var path = require('path');

ghdownload({
  user: 'jprichardson',
  repo: 'node-github-download',
  ref: 'v0.2.0'
}, path.join(__dirname, 'node-github-download'));
```

I get this Error: `ENOENT: no such file or directory, rename 'C:\path\to\dir\name\1462353779471-9935504384338856\node-github-download-v0.2.0' -> 'C:\path\to\dir\name\node-github-download'`.

And that because the folder `node-github-download-v0.2.0` doesn't exists, and actually it is `node-github-download-0.2.0`, you can download the zip [here](https://github.com/jprichardson/node-github-download/archive/v0.2.0.zip) and see for yourself (github removes `v` for some reason).

Changed the code so it will take the folder name from the first entry instead.
Would love to see this implemented soon, thanks in advance.
